### PR TITLE
Add Status reporting for DO280

### DIFF
--- a/ansible/configs/ansible-skylight/pre_software.yml
+++ b/ansible/configs/ansible-skylight/pre_software.yml
@@ -34,7 +34,7 @@
   become: true
   roles:
     - { role: "bastion", when: 'install_bastion' }
-    - { role: "status-report-install", when: 'report_status' }
+    - { role: "status-report-install", when: 'report_status | d(false)' }
   tags:
     - step004
     - bastion_tasks

--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -378,5 +378,27 @@
   gather_facts: false
   become: false
   tasks:
+  - name: Get kubeadmin password
+    slurp:
+      path: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password
+    register: kubeadminr
+    when: report_status
+  - name: Get Cluster ID
+    environment:
+      KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+    command: oc get clusterversion version -o jsonpath="{.spec.clusterID}"
+    register: clusteridr
+
+  - name: Set cluster id
+    set_fact:
+      cluster_id: "{{ clusteridr.stdout | trim }}"
+  - name: Report provisioning status
+    include_role:
+      name: status-report
+    vars:
+      classroom_status: "Classroom ready"
+      status_json: "{{ lookup('template', 'report.j2') }}"
+      bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+    when: report_status
   - debug:
       msg: "Post-Software checks completed successfully"

--- a/ansible/configs/ocp4-workshop/pre_software.yml
+++ b/ansible/configs/ocp4-workshop/pre_software.yml
@@ -45,6 +45,10 @@
   become: true
   roles:
   - { role: "bastion",              when: 'install_bastion | bool' }
+  - role: "status-report-install"
+    vars:
+      bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}" 
+    when: 'report_status | d(false)'
   - { role: "bastion-student-user", when: 'install_student_user | bool' }
   - { role: "bastion-opentlc-ipa",  when: 'install_ipa_client | bool' }
   tags:

--- a/ansible/configs/ocp4-workshop/requirements.yml
+++ b/ansible/configs/ocp4-workshop/requirements.yml
@@ -4,3 +4,7 @@
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
   version: v0.11
+
+# From 'Stouts.wsgi'
+- src: https://github.com/Stouts/Stouts.wsgi
+  version: 2.1.4

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -1,4 +1,19 @@
 ---
+- name: OpenShift Provisioning Pre-Tasks
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: no
+  tasks:
+    - name: Report provisioning status
+      include_role:
+        name: status-report
+      vars:
+        classroom_status: "Starting the OpenShift Installation"
+        status_json: "{{ lookup('template', 'report-before-install.j2') }}"
+        bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+      when: report_status
+
 - name: Step 00xxxxx software
   hosts: bastions
   gather_facts: false
@@ -212,6 +227,16 @@
           command: oc whoami --show-server
           register: showserver
 
+        - name: Get Cluster ID
+          environment:
+            KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+          command: oc get clusterversion version -o jsonpath="{.spec.clusterID}"
+          register: clusteridr
+
+        - name: Set cluster id
+          set_fact:
+            cluster_id: "{{ clusteridr.stdout | trim }}"
+
         - name: Print Overview
           debug:
             msg: "{{ item }}"
@@ -241,6 +266,15 @@
             - "user.info: "
             - "user.info: You *CANNOT* SSH into this environment"
           when: not install_student_user | bool
+
+        - name: Report provisioning status
+          include_role:
+            name: status-report
+          vars:
+            classroom_status: "OpenShift Installation Completed"
+            status_json: "{{ lookup('template', 'report.j2') }}"
+            bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+          when: report_status          
 
       always:
         - name: Delete deployinprogress lock file

--- a/ansible/configs/ocp4-workshop/templates/report-before-install.j2
+++ b/ansible/configs/ocp4-workshop/templates/report-before-install.j2
@@ -1,0 +1,1 @@
+{ "classroom_identifier": "{{ guid }}", "classroom_type": "{{ env_type }}", "classroom_region": "{{ aws_region }}", "status": "{{ classroom_status | d('unknown') }}" }

--- a/ansible/configs/ocp4-workshop/templates/report.j2
+++ b/ansible/configs/ocp4-workshop/templates/report.j2
@@ -1,0 +1,1 @@
+{ "cluster_id": "{{ cluster_id }}", "cluster_username": "kubeadmin", "cluster_password": "{{ kubeadminr.content | b64decode }}", "cluster_api_url": "api.{{cluster_name}}{{subdomain_base_suffix}}:6443", "classroom_identifier": "{{ guid }}", "classroom_type": "{{ env_type }}", "classroom_region": "{{ aws_region }}", "status": "{{ classroom_status | d('unknown') }}" }

--- a/ansible/roles/status-report-install/defaults/main.yml
+++ b/ansible/roles/status-report-install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"

--- a/ansible/roles/status-report-install/tasks/main.yml
+++ b/ansible/roles/status-report-install/tasks/main.yml
@@ -28,14 +28,14 @@
   shell: |
     semanage port -a -t http_port_t -p tcp 30904
     semanage port -m -t http_port_t -p tcp 30904
-    
+
 - name: Install python application as a service
   include_role:
     name: Stouts.wsgi
   vars:
     python_enabled: false
     wsgi_group: nginx
-    wsgi_nginx_servernames: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
+    wsgi_nginx_servernames: "{{ bastion_dns_name }}"
     wsgi_nginx_port: 30904
     wsgi_applications:
     - name: status

--- a/ansible/roles/status-report/tasks/main.yml
+++ b/ansible/roles/status-report/tasks/main.yml
@@ -1,7 +1,12 @@
 ---
+- name:
+  set_fact:
+    bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
+  when: bastion_dns_name is not defined
+
 - name: Report provisioning status
   uri:
-    url: "http://bastion.{{ guid }}{{ subdomain_base_suffix }}:30904/api/provision/v1/report"
+    url: "http://{{ bastion_dns_name }}:30904/api/provision/v1/report"
     method: POST
     body: "{{ status_json }}"
     status_code: 200


### PR DESCRIPTION
##### SUMMARY
DO280 was not using the new bastion API for reporting status of the provision. Added the ability in ocp4-workshop to do so.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
configs/ocp4-workshop and corresponding roles

##### ADDITIONAL INFORMATION
None
