### PR TITLE
Make OpenShift CSR signing more efficient

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -81,6 +81,7 @@
           instance-state-name: stopped
           # TODO: uncomment this in a few weeks
           #"tag:env_type": "{{ env_type }}"
+      ignore_errors: true
 
     - when: ACTION == 'status'
       block:
@@ -111,12 +112,23 @@
       pause:
         seconds: "{{ lifecycle_start_pause | default(300) }}"
 
-    - name: Get CSRs that need to be patched
-      command: oc get csr -oname
-      register: r_csrs
-      changed_when: false
+    # - name: Get CSRs that need to be patched
+    #   command: oc get csr -oname
+    #   register: r_csrs
+    #   changed_when: false
+    #
+    # - when: r_csrs.stdout_lines | length > 0
+    #   name: Approve all Pending CSRs
+    #   command: "oc adm certificate approve {{ item }}"
+    #   loop: "{{ r_csrs.stdout_lines }}"
 
-    - when: r_csrs.stdout_lines | length > 0
-      name: Approve all Pending CSRs
-      command: "oc adm certificate approve {{ item }}"
-      loop: "{{ r_csrs.stdout_lines }}"
+    - name: Get pending CSRs and approve them
+      shell: |
+        for i in `oc get csr --no-headers|grep -v Approved|cut -d' ' -f1`; do
+          oc adm certificate approve $i
+        done
+      register: approval
+
+    - name: Print CSRs approved, if any
+      debug:
+        msg: "{{approval.stdout_lines}}"


### PR DESCRIPTION
Sign only pending CSRs making start up much faster for OpenShift 4.x clusters

##### SUMMARY
We noticed that sometimes the signing process, particularly for large numbers of CSRs was taking a long time to run and resulted in not all certs getting signed because some were generated while it was signing the others!

We used a shell task to screen out approved CSRs and only approve pending ones.  This greatly improved performance of the start up lifecycle (ocp4-workshop config).

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4-workshop/lifecycle.yml

##### ADDITIONAL INFORMATION
None
