### PR TITLE
Move windows AMIs to 2020.07.15

### DIFF
--- a/ansible/roles/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles/infra-ec2-template-generate/defaults/main.yml
@@ -101,10 +101,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0aa4317636e016115 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-5c2f7e33 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-03087b28576b37511 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-03cf4edc1a23b182c # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-002aa17df8c86f635 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0e3eeeaf6147c7391 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0d0b566c7d15a03a3 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-064ef1765849c7f6f # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0f550bdb648e94c38 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0d630072ba63de80f # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-03dbf9550d4620230 # Windows_Server-2019-English-Full-Base-2020.07.15
   eu-west-3:
     RHEL76GOLD: ami-0a74212566be8f9e2 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0a0167e3e2a1d1d9b # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -112,10 +112,10 @@ aws_ami_region_mapping:
     RHEL75: ami-039346fed23fb53ad # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-66d0661b # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-080d3d8def91e4f44 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0ebc77e70368c1566 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-09dbf6353100bde3a # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-039321016220a8aec # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0fbd0855b000b195a # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-07fc052afe45c3ff8 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-035886e9921128d1a # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-03edea334564211f6 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0ace5ff23b1a4725d # Windows_Server-2019-English-Full-Base-2020.07.15
   eu-west-2:
     RHEL76GOLD: ami-051fb39c3a16c8a85 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-01f010afd559615b9 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -123,10 +123,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0ac5fae255ddac6f6 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-b4b3a8d0 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0699aabf510a3f2f8 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-06b82db8c2abe63ff # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-01de3128ed02d9e1c # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0827ab01bb202c7f5 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0355df7fad2bfb4f9 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-033b72cc05c5e02f8 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-02d88d373bf2a487a # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0a48d915cc2b3a0d6 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0c80f4021417f8488 # Windows_Server-2019-English-Full-Base-2020.07.15
   eu-west-1:
     RHEL76GOLD: ami-02a1dcbcc4f50bdb9 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0c51cd02617947143 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -134,10 +134,10 @@ aws_ami_region_mapping:
     RHEL75: ami-092acf20fad7f7795 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-ccb7d2b5 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0370c806916d2a17f # Windows_Server-2012-R2_RTM-English-64Bit-HyperV-2018.09.15
-    WIN2016CORE: ami-006878ea4eedaebe3 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0d3e6055f3c1699c6 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-07d81c6209308d3e4 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-07c8a3a59f2f7305b # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-00e0e67465335e652 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0d30f8acc8b87dfd7 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-03245aa919d9d053d # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0753ddff1a67fca78 # Windows_Server-2019-English-Full-Base-2020.07.15
   ap-northeast-2:
     RHEL76GOLD: ami-0983c35dbbdd0f69e # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-031161cd3182e012a # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -145,10 +145,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0d226f15e3e46903a # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-90a201fe # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-02ee840e33e7c2244 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-08b1eee794b73f39e # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-061928edf87ae6cad # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0230f72046e2bc8d8 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0419b1bc0ae0409c1 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-0abf30c9983728cef # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0af26a26ce589d298 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0090630e14b85ef16 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-049e67b9661b9ee3e # Windows_Server-2019-English-Full-Base-2020.07.15
   ap-northeast-1:
     RHEL76GOLD: ami-0b1fa7354371d3331 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0bf9ecb88f5719e17 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -156,10 +156,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0b517025bb2f0ad4a # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-36f09350 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-08e310c576c077de1 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0fedd6ec83b2a464a # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0f15599e3fcc4b8a4 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0d4fa92c2deedf213 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-008755994dfc325f7 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-09d8a74fd8a32fc64 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-09b4882469bcc17c5 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0899ebbbdc38143ff # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0f1d9d91c16265769 # Windows_Server-2019-English-Full-Base-2020.07.15
   sa-east-1:
     RHEL76GOLD: ami-06addb952810f166b # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-93b693ff # RHEL-7.5_HVM_GA-JBEAP-7.1.2-20180629-x86_64-1-Access2-GP2
@@ -167,10 +167,10 @@ aws_ami_region_mapping:
     RHEL75: ami-01c56172f9db84834 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-1a064a76 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-079f7c686ba77c199 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0cf4d672678356fb2 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-08393c14aa221a1a2 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0fd2622602a8f44e1 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0b3d9fa7386b999a4 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-02a49569e46adbd3b # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-06752a5f4a306b265 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0d6327695c7f61972 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-066d7f29fb6c7b3bb # Windows_Server-2019-English-Full-Base-2020.07.15
   ca-central-1:
     RHEL76GOLD: ami-0ed2e023e005c9178 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-e320ad87 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -178,10 +178,10 @@ aws_ami_region_mapping:
     RHEL75: ami-fc20ad98 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-71018415 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-020be7519c99e8064 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-08c457f60a55cb585 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-02c212eea0b630bbf # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0ef9a77c529e5e17b # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-09318195b724a7126 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-02cee02b2331d7446 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-05f72a4e2c483b7dd # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-00a340efdbd9a81c4 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0df364e027762ec43 # Windows_Server-2019-English-Full-Base-2020.07.15
   ap-southeast-1:
     RHEL76GOLD: ami-070467cd1ef12f289 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0f44e46fa59e902b6 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -189,10 +189,10 @@ aws_ami_region_mapping:
     RHEL75: ami-09fc728e15fbfb535 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-8d90e9f1 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0906117a55c70d5e7 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0b9908d35b59b25a4 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0869caa73f897a75b # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-08304b7dee56eb60e # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0fdb514b22fa2aed1 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-031195cdaa298360d # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-04ad4f8adb6cd9ae2 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-06c91a6ab627f6f99 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-003ad59a0b2b3c98f # Windows_Server-2019-English-Full-Base-2020.07.15
   ap-southeast-2:
     RHEL76GOLD: ami-0499d01ff89fea5e6 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0066ef2f9c72fad96 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -200,10 +200,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0a61d60bde3940420 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-e1996783 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-09fb195e1d6625aab # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0de5a5f0d61201525 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0d74db61e73aba053 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-03535f55bb752a325 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-030bf0fa163eee558 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-048d17fc485518266 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0a1c4ca298cf1cfd0 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0dae47fc4057031a9 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-09a17b63e7283d6a2 # Windows_Server-2019-English-Full-Base-2020.07.15
   eu-central-1:
     RHEL76GOLD: ami-012838bc227c83b03 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-07d3f0705bebac978 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -211,10 +211,10 @@ aws_ami_region_mapping:
     RHEL75: ami-05ba90b00a46d83fa # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-8a21bfe5 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-07b8613a03480d559 # Windows_Server-2012-R2_RTM-English-64Bit-HyperV-2018.09.15
-    WIN2016CORE: ami-02d0b63f62520c751 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0e8ecd9d5c3d37a71 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0525cf38af7933533 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-06f553152bb794f14 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-03ced2abe665b774c # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-041b3f8816c94b62c # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-065dba2653338d08e # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0075ac87f3bb991bc # Windows_Server-2019-English-Full-Base-2020.07.15
   us-east-1:
     RHEL76GOLD: ami-0f83261cb7d041a1b #RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0456c465f72bd0c95 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -222,10 +222,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0394fe9914b475c53 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-76a3970c # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-003027603b9c132b3 # Windows_Server-2012-R2_RTM-Japanese-64Bit-SQL_2016_SP1_Express-2018.09.15
-    WIN2016CORE: ami-0355e0f9f636384c7 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0f7122ac3de6f22b2 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0e6aec11efb9b031c # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0c278895328cddfdd # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-05c99ae8c6af2e6db # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-081afb283b98a8548 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0a444da9866ff3f59 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0f38562b9d4de0dfe # Windows_Server-2019-English-Full-Base-2020.07.15
   us-east-2:
     RHEL76GOLD: ami-0bdf2c4eae6c71d2b # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-04268981d7c33264d # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -233,10 +233,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0376bbf9be9eac670 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-cebe94ab # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-02fa46b8e1a36044b # Windows_Server-2012-R2_RTM-English-P3-2018.09.15
-    WIN2016CORE: ami-08a82ce672d0fdd64 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0b2ce977c1b36856d # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-03b93660b63d651d5 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-08db69d5de9dc9245 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-06267f9b2341ce274 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0587770c46124f677 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-0b234f82fd2a6e7bc # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-066a1a3fa81bfbd00 # Windows_Server-2019-English-Full-Base-2020.07.15
   us-west-1:
     RHEL76GOLD: ami-00ef21b27071fe235 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-02574210e91c38419 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -244,10 +244,10 @@ aws_ami_region_mapping:
     RHEL75: ami-0bdc0ff10fb093057 # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-c8020fa8 # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0f9c4789993c313f7 # Windows_Server-2012-R2_RTM-English-Deep-Learning-2018.09.15
-    WIN2016CORE: ami-0868388e04c63e28c # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-06894046d41571622 # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0c5745a13d3c24724 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-0390f4b65b4cbe84a # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-00a0bc84c13a43472 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-022b8726b80fd1330 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-08f9d9bd7c14c009e # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-0d1b8b740ddc3b78d # Windows_Server-2019-English-Full-Base-2020.07.15
   us-west-2:
     RHEL76GOLD: ami-0fae471393c00f216 # RHEL-7.6_HVM-20190618-x86_64-0-Access2-GP2
     RHEL75GOLD: ami-0e6bab6682ec471c0 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
@@ -255,7 +255,7 @@ aws_ami_region_mapping:
     RHEL75: ami-096510cab1b6b2c6d # RHEL-7.5_HVM-20180813-x86_64-0-Hourly2-GP2
     RHEL74: ami-1607ba6e # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0d786d5cc800b2456 # Windows_Server-2012-R2_RTM-English-64Bit-HyperV-2018.09.15
-    WIN2016CORE: ami-0d104799305b7f212 # Windows_Server-2016-English-Core-Base-2020.04.15
-    WIN2016FULL: ami-0f26f5844bdf3c2ad # Windows_Server-2016-English-Full-Base-2020.04.15
-    WIN2019CORE: ami-0bc20ca2c4f2135a8 # Windows_Server-2019-English-Core-Base-2020.04.15
-    WIN2019FULL: ami-059377ba193aa9309 # Windows_Server-2019-English-Full-Base-2020.04.15
+    WIN2016CORE: ami-0464bbc60a2c6b619 # Windows_Server-2016-English-Core-Base-2020.07.15
+    WIN2016FULL: ami-0fb16d6843cf910d7 # Windows_Server-2016-English-Full-Base-2020.07.15
+    WIN2019CORE: ami-097cb222fb8c28e57 # Windows_Server-2019-English-Core-Base-2020.07.15
+    WIN2019FULL: ami-09fa39d0afa9024db # Windows_Server-2019-English-Full-Base-2020.07.15


### PR DESCRIPTION
Update the AMI identifier list to point to the Windows 2020.07.15 releases.