### PR TITLE
Fix Broken Links and Boost Workstation Performance

### DIFF
--- a/ansible/configs/ansible-skylight/env_vars.yml
+++ b/ansible/configs/ansible-skylight/env_vars.yml
@@ -82,7 +82,7 @@ gitlab_instance_type: "t2.medium"
 windows_instance_count: 2
 windows_instance_type: "t3.medium"
 
-windows_workstation_instance_type: "t3.large"
+windows_workstation_instance_type: "m5.large"
 
 activedirectory_instance_count: 1
 activedirectory_instance_type: "t3.medium"

--- a/ansible/roles/skylight-windows-workstation/tasks/adv_lab.yml
+++ b/ansible/roles/skylight-windows-workstation/tasks/adv_lab.yml
@@ -2,11 +2,11 @@
 - block:
   - name: Create an shortcut to Advanced Docs site
     win_shortcut:
-      src: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe'
+      src: '%ProgramFiles%\Google\Chrome\Application\chrome.exe'
       dest: '%UserProfile%\Desktop\Advanced Workshop Docs.lnk'
       args: --new-window http://docs.{{ dns_domain_name }}/advanced/
-      directory: '%ProgramFiles(x86)%\Google\Chrome\Application'
-      icon: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe,0'
+      directory: '%ProgramFiles%\Google\Chrome\Application'
+      icon: '%ProgramFiles%\Google\Chrome\Application\chrome.exe,0'
 
   become: yes
   become_user: "{{ dns_domain_name_short }}\\{{ user_prefix }}"

--- a/ansible/roles/skylight-windows-workstation/tasks/git_lab.yml
+++ b/ansible/roles/skylight-windows-workstation/tasks/git_lab.yml
@@ -2,11 +2,11 @@
 - block:
   - name: Create an shortcut to GIT Docs site
     win_shortcut:
-      src: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe'
+      src: '%ProgramFiles%\Google\Chrome\Application\chrome.exe'
       dest: '%UserProfile%\Desktop\GIT Workshop Docs.lnk'
       args: --new-window http://docs.{{ dns_domain_name }}/git/
-      directory: '%ProgramFiles(x86)%\Google\Chrome\Application'
-      icon: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe,0'
+      directory: '%ProgramFiles%\Google\Chrome\Application'
+      icon: '%ProgramFiles%\Google\Chrome\Application\chrome.exe,0'
 
   become: yes
   become_user: "{{ dns_domain_name_short }}\\{{ user_prefix }}"

--- a/ansible/roles/skylight-windows-workstation/tasks/main.yml
+++ b/ansible/roles/skylight-windows-workstation/tasks/main.yml
@@ -86,27 +86,27 @@
 
   - name: Create a shortcut to Tower site
     win_shortcut:
-      src: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe'
+      src: '%ProgramFiles%\Google\Chrome\Application\chrome.exe'
       dest: '%UserProfile%\Desktop\Ansible Tower.lnk'
       args: --new-window http://tower.{{ dns_domain_name }}/
-      directory: '%ProgramFiles(x86)%\Google\Chrome\Application'
-      icon: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe,0'
+      directory: '%ProgramFiles%\Google\Chrome\Application'
+      icon: '%ProgramFiles%\Google\Chrome\Application\chrome.exe,0'
 
   - name: Create a shortcut to the user's Gitlab ansible-playbooks repository
     win_shortcut:
-      src: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe'
+      src: '%ProgramFiles%\Google\Chrome\Application\chrome.exe'
       dest: '%UserProfile%\Desktop\GitLab.lnk'
       args: --new-window https://gitlab.{{ dns_domain_name }}/{{ user_prefix }}
-      directory: '%ProgramFiles(x86)%\Google\Chrome\Application'
-      icon: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe,0'
+      directory: '%ProgramFiles%\Google\Chrome\Application'
+      icon: '%ProgramFiles%\Google\Chrome\Application\chrome.exe,0'
 
   - name: Create a shortcut to Ansible Docs site
     win_shortcut:
-      src: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe'
+      src: '%ProgramFiles%\Google\Chrome\Application\chrome.exe'
       dest: '%UserProfile%\Desktop\Ansible Docs.lnk'
       args: --new-window http://docs.ansible.com/
-      directory: '%ProgramFiles(x86)%\Google\Chrome\Application'
-      icon: '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe,0'
+      directory: '%ProgramFiles%\Google\Chrome\Application'
+      icon: '%ProgramFiles%\Google\Chrome\Application\chrome.exe,0'
 
   - name: Set git to cache credentials
     win_command: git config --global credential.helper manager


### PR DESCRIPTION
##### SUMMARY
The location for the installation of the Google Chrome browser changed.  This broke the links on the desktop for things like GitLab and Ansible Tower.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Ansible-skylight playbook, role skylight-windows-workstation

##### ADDITIONAL INFORMATION
None
