### PR TITLE
Fix version of pip at 20.3 so there is no conflict with virtualenv

### DIFF
--- a/ansible/roles/status-report-install/tasks/main.yml
+++ b/ansible/roles/status-report-install/tasks/main.yml
@@ -22,9 +22,7 @@
     - server.py
     - wsgi.py
 - name: Upgrade pip
-  pip:
-    name: pip
-    state: latest
+  command: pip2 install pip==20.3 --upgrade 
 - name: Install python virtualenv
   pip:
     name: virtualenv


### PR DESCRIPTION
Bug fix.
Pip migrated to version 21.0 and it was not compatible with the version of Python we are running (2.7.5) and conflicted with virtualenv==20.0.18.

Anchored pip to version 20.3.
