### PR TITLE
Fix ansible-skylight tower build problems with PIP

### DIFF
--- a/ansible/roles/skylight-ansible-tower/tasks/main.yml
+++ b/ansible/roles/skylight-ansible-tower/tasks/main.yml
@@ -40,7 +40,11 @@
     group: root
     mode: 0644
 
+- name: Update Pip
+  command: pip install --upgrade pip==20.3
+
 - name: install the last version of OpenSSL
+  become: no
   pip:
     name: pyOpenSSL
     state: latest
@@ -58,6 +62,7 @@
     use_backend: dnf
 
 - name: Install pywinrm for connecting to windows hosts
+  become: no
   pip:
     name:
       - pywinrm>=0.2.2

--- a/ansible/roles/skylight-ansible-tower/tasks/main.yml
+++ b/ansible/roles/skylight-ansible-tower/tasks/main.yml
@@ -40,14 +40,14 @@
     group: root
     mode: 0644
 
-- name: Update Pip
-  command: pip install --upgrade pip==20.3
-
-- name: install the last version of OpenSSL
-  become: no
-  pip:
-    name: pyOpenSSL
-    state: latest
+# - name: Update Pip
+#   command: pip install --upgrade pip==20.3
+#
+# - name: install the last version of OpenSSL
+#   become: no
+#   pip:
+#     name: pyOpenSSL
+#     state: latest
 
 - name: Install dependencies for Kerberos auth
   yum:
@@ -61,13 +61,13 @@
     state: present
     use_backend: dnf
 
-- name: Install pywinrm for connecting to windows hosts
-  become: no
-  pip:
-    name:
-      - pywinrm>=0.2.2
-      - pywinrm[kerberos]
-      - pywinrm[credssp]
+# - name: Install pywinrm for connecting to windows hosts
+#   # become: no
+#   pip:
+#     name:
+#       - pywinrm>=0.2.2
+#       - pywinrm[kerberos]
+#       - pywinrm[credssp]
 
 #- name: Install requests-credssp for Tower 3.2
 #  pip:


### PR DESCRIPTION
##### SUMMARY
Fix issue with tower build bombing out because pyOpenSSL and pywinrm were being upgraded/installed and didn't need to be.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-skylight

##### ADDITIONAL INFORMATION
tower build
